### PR TITLE
feat: Add seekForward and seekBackward

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # spotify-node-applescript
+
 Control Spotify on Mac OSX with NodeJS and AppleScript.
 
 ## Installation
@@ -20,10 +21,10 @@ $ npm test
 Play a track with Spotify URI `uri`.
 
 ```javascript
-var spotify = require('spotify-node-applescript');
+var spotify = require("spotify-node-applescript");
 
-spotify.playTrack('spotify:track:3AhXZa8sUQht0UEdBJgpGc', function(){
-    // track is playing
+spotify.playTrack("spotify:track:3AhXZa8sUQht0UEdBJgpGc", function () {
+  // track is playing
 });
 ```
 
@@ -32,11 +33,15 @@ spotify.playTrack('spotify:track:3AhXZa8sUQht0UEdBJgpGc', function(){
 Play a track in context of for example an album.
 
 ```javascript
-var spotify = require('spotify-node-applescript');
+var spotify = require("spotify-node-applescript");
 
-spotify.playTrackInContext('spotify:track:0R8P9KfGJCDULmlEoBagcO', 'spotify:album:6ZG5lRT77aJ3btmArcykra', function(){
+spotify.playTrackInContext(
+  "spotify:track:0R8P9KfGJCDULmlEoBagcO",
+  "spotify:album:6ZG5lRT77aJ3btmArcykra",
+  function () {
     // Track is playing in context of an album
-});
+  }
+);
 ```
 
 ### getTrack(callback)
@@ -44,11 +49,10 @@ spotify.playTrackInContext('spotify:track:0R8P9KfGJCDULmlEoBagcO', 'spotify:albu
 Get the current track. `callback` is called with the current track as second argument.
 
 ```javascript
-var spotify = require('spotify-node-applescript');
+var spotify = require("spotify-node-applescript");
 
-spotify.getTrack(function(err, track){
-
-    /*
+spotify.getTrack(function (err, track) {
+  /*
     track = {
         artist: 'Bob Dylan',
         album: 'Highway 61 Revisited',
@@ -65,7 +69,6 @@ spotify.getTrack(function(err, track){
         spotify_url: 'spotify:track:3AhXZa8sUQht0UEdBJgpGc' }
     }
     */
-
 });
 ```
 
@@ -74,10 +77,10 @@ spotify.getTrack(function(err, track){
 Get player state.
 
 ```javascript
-var spotify = require('spotify-node-applescript');
+var spotify = require("spotify-node-applescript");
 
-spotify.getState(function(err, state){
-    /*
+spotify.getState(function (err, state) {
+  /*
     state = {
         volume: 99,
         position: 232,
@@ -92,10 +95,10 @@ spotify.getState(function(err, state){
 Jump to a specific second of the current song.
 
 ```javascript
-var spotify = require('spotify-node-applescript');
+var spotify = require("spotify-node-applescript");
 
-spotify.jumpTo(15, function() {
-    console.log('Jumped 15th second of the song');
+spotify.jumpTo(15, function () {
+  console.log("Jumped 15th second of the song");
 });
 ```
 
@@ -132,12 +135,12 @@ Turn volume down.
 Sets the volume.
 
 ```javascript
-var spotify = require('spotify-node-applescript');
+var spotify = require("spotify-node-applescript");
 
-spotify.setVolume(42, function() {
-    spotify.getState(function(err, state) {
-        console.log(state.volume);
-    });
+spotify.setVolume(42, function () {
+  spotify.getState(function (err, state) {
+    console.log(state.volume);
+  });
 });
 ```
 
@@ -154,49 +157,58 @@ Returns audio to original volume.
 Check if Spotify is running.
 
 ```javascript
-var spotify = require('spotify-node-applescript');
+var spotify = require("spotify-node-applescript");
 
-spotify.isRunning(function(err, isRunning){
-    console.log(isRunning); // true
+spotify.isRunning(function (err, isRunning) {
+  console.log(isRunning); // true
 });
 ```
 
 ### isRepeating(callback)
-Is repeating on or off?
-```js
-var spotify = require('spotify-node-applescript');
 
-spotify.isRepeating(function(err, shuffling){
-    console.log(shuffling); // true || false
+Is repeating on or off?
+
+```js
+var spotify = require("spotify-node-applescript");
+
+spotify.isRepeating(function (err, shuffling) {
+  console.log(shuffling); // true || false
 });
 ```
 
 ### isShuffling(callback)
-Is shuffling on or off?
-```js
-var spotify = require('spotify-node-applescript');
 
-spotify.isShuffling(function(err, shuffling){
-    console.log(shuffling); // true || false
+Is shuffling on or off?
+
+```js
+var spotify = require("spotify-node-applescript");
+
+spotify.isShuffling(function (err, shuffling) {
+  console.log(shuffling); // true || false
 });
 ```
-### setRepeating(repeating/\**boolean*\*/, callback)
+
+### setRepeating(repeating/\*_boolean_\*/, callback)
+
 Sets repeating on or off
 
-### setShuffling(shuffling/\**boolean*\*/, callback)
+### setShuffling(shuffling/\*_boolean_\*/, callback)
+
 Sets shuffling on or off
 
 ### toggleRepeating(callback)
+
 Toggles repeating
 
 ### toggleShuffling(callback)
+
 Toggles shuffling
 
 ## Contributors
 
-* [Robin Mehner](https://github.com/rmehner)
-* [Thorsten Ball](https://github.com/mrnugget)
-* [Paul Marbach](https://github.com/fastfrwrd)
+- [Robin Mehner](https://github.com/rmehner)
+- [Thorsten Ball](https://github.com/mrnugget)
+- [Paul Marbach](https://github.com/fastfrwrd)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -102,6 +102,30 @@ spotify.jumpTo(15, function () {
 });
 ```
 
+### seekForward(second, callback)
+
+Seek forward for the given seconds in the current song.
+
+```javascript
+var spotify = require("spotify-node-applescript");
+
+spotify.seekForward(5, function () {
+  console.log("Seeked forward for 5 seconds in the current song");
+});
+```
+
+### seekBackward(second, callback)
+
+Seek backward for the given seconds in the current song.
+
+```javascript
+var spotify = require("spotify-node-applescript");
+
+spotify.seekBackward(5, function () {
+  console.log("Seeked backward for 5 seconds in the current song");
+});
+```
+
 ### play(callback)
 
 Resume playing current track.
@@ -209,6 +233,7 @@ Toggles shuffling
 - [Robin Mehner](https://github.com/rmehner)
 - [Thorsten Ball](https://github.com/mrnugget)
 - [Paul Marbach](https://github.com/fastfrwrd)
+- [dyong1](https://github.com/dyong1)
 
 ## License
 

--- a/lib/spotify-node-applescript.js
+++ b/lib/spotify-node-applescript.js
@@ -61,37 +61,37 @@ var scripts = {
 
 var scriptsPath = __dirname + '/scripts/';
 
-var execScript = function(scriptName, params, callback){
-    if (arguments.length === 2 && typeof params === 'function'){
+var execScript = function (scriptName, params, callback) {
+    if (arguments.length === 2 && typeof params === 'function') {
         // second argument is the callback
         callback = params;
         params = undefined;
     }
 
     // applescript lib needs a callback, but callback is not always useful
-    if (!callback) callback = function(){};
+    if (!callback) callback = function () { };
 
-    if (typeof params !== 'undefined' && !Array.isArray(params)){
+    if (typeof params !== 'undefined' && !Array.isArray(params)) {
         params = [params];
     }
 
     var script = scripts[scriptName];
 
-    if (typeof script === 'string'){
+    if (typeof script === 'string') {
         if (typeof params !== 'undefined') script = util.format.apply(util, [script].concat(params));
         return applescript.execString(script, callback);
-    } else if (script.file){
+    } else if (script.file) {
         return applescript.execFile(scriptsPath + script.file, callback);
     }
 };
 
-var createJSONResponseHandler = function(callback, flag){
+var createJSONResponseHandler = function (callback, flag) {
     if (!callback) return null;
-    return function(error, result){
-        if (!error){
+    return function (error, result) {
+        if (!error) {
             try {
                 result = JSON.parse(result);
-            } catch(e){
+            } catch (e) {
                 console.log(flag, result);
                 return callback(e);
             }
@@ -102,8 +102,8 @@ var createJSONResponseHandler = function(callback, flag){
     };
 };
 
-var createBooleanResponseHandler = function(callback){
-    return function(error, response) {
+var createBooleanResponseHandler = function (callback) {
+    return function (error, response) {
         if (!error) {
             return callback(null, response === 'true');
         } else {
@@ -117,57 +117,57 @@ var createBooleanResponseHandler = function(callback){
 
 // Open track
 
-exports.open = function(uri, callback){
-    return exec('open "'+uri+'"', callback);
+exports.open = function (uri, callback) {
+    return exec('open "' + uri + '"', callback);
 };
 
-exports.playTrack = function(track, callback){
+exports.playTrack = function (track, callback) {
     return execScript('playTrack', track, callback);
 };
 
-exports.playTrackInContext = function(track, context, callback){
+exports.playTrackInContext = function (track, context, callback) {
     return execScript('playTrackInContext', [track, context], callback);
 };
 
 // Playback control
 
-exports.play = function(callback){
+exports.play = function (callback) {
     return execScript('play', callback);
 };
 
-exports.pause = function(callback){
+exports.pause = function (callback) {
     return execScript('pause', callback);
 };
 
-exports.playPause = function(callback){
+exports.playPause = function (callback) {
     return execScript('playPause', callback);
 };
 
-exports.next = function(callback){
+exports.next = function (callback) {
     return execScript('next', callback);
 };
 
-exports.previous = function(callback){
+exports.previous = function (callback) {
     return execScript('previous', callback);
 };
 
-exports.jumpTo = function(position, callback){
+exports.jumpTo = function (position, callback) {
     return execScript('jumpTo', position, callback);
 };
 
-exports.setRepeating = function(repeating, callback){
+exports.setRepeating = function (repeating, callback) {
     return execScript('setRepeating', repeating, callback);
 };
 
-exports.setShuffling = function(shuffling, callback){
+exports.setShuffling = function (shuffling, callback) {
     return execScript('setShuffling', shuffling, callback);
 };
 
-exports.toggleRepeating = function(callback){
+exports.toggleRepeating = function (callback) {
     return execScript('toggleRepeating', callback);
 };
 
-exports.toggleShuffling = function(callback){
+exports.toggleShuffling = function (callback) {
     return execScript('toggleShuffling', callback);
 };
 
@@ -175,29 +175,29 @@ exports.toggleShuffling = function(callback){
 
 var mutedVolume = null;
 
-exports.volumeUp = function(callback){
+exports.volumeUp = function (callback) {
     mutedVolume = null;
     return execScript('volumeUp', callback);
 };
 
-exports.volumeDown = function(callback){
+exports.volumeDown = function (callback) {
     mutedVolume = null;
     return execScript('volumeDown', callback);
 };
 
-exports.setVolume = function(volume, callback){
+exports.setVolume = function (volume, callback) {
     mutedVolume = null;
     return execScript('setVolume', volume, callback);
 };
 
-exports.muteVolume = function(callback){
-    return execScript('state', createJSONResponseHandler(function(err, state){
+exports.muteVolume = function (callback) {
+    return execScript('state', createJSONResponseHandler(function (err, state) {
         exports.setVolume(0, callback);
         mutedVolume = state.volume;
     }));
 };
 
-exports.unmuteVolume = function(callback){
+exports.unmuteVolume = function (callback) {
     if (mutedVolume !== null) {
         return exports.setVolume(mutedVolume, callback);
     }
@@ -205,23 +205,23 @@ exports.unmuteVolume = function(callback){
 
 // State retrieval
 
-exports.getTrack = function(callback){
+exports.getTrack = function (callback) {
     return execScript('track', createJSONResponseHandler(callback, 'track'));
 };
 
-exports.getState = function(callback){
+exports.getState = function (callback) {
     return execScript('state', createJSONResponseHandler(callback, 'state'));
 };
 
-exports.isRunning = function(callback) {
+exports.isRunning = function (callback) {
     return execScript('isRunning', createBooleanResponseHandler(callback));
 };
 
-exports.isRepeating = function(callback){
+exports.isRepeating = function (callback) {
     return execScript('isRepeating', createBooleanResponseHandler(callback));
 };
 
-exports.isShuffling = function(callback){
+exports.isShuffling = function (callback) {
     return execScript('isShuffling', createBooleanResponseHandler(callback));
 };
 

--- a/lib/spotify-node-applescript.js
+++ b/lib/spotify-node-applescript.js
@@ -36,6 +36,10 @@ var scripts = {
         'tell application "Spotify" to next track',
     previous:
         'tell application "Spotify" to previous track',
+    seekForward:
+        'tell application "Spotify" to set player position to (player position + %s)',
+    seekBackward:
+        'tell application "Spotify" to set player position to (player position - %s)',
     jumpTo:
         'tell application "Spotify" to set player position to %s',
     isRunning:
@@ -149,6 +153,14 @@ exports.next = function (callback) {
 
 exports.previous = function (callback) {
     return execScript('previous', callback);
+};
+
+exports.seekForward = function (seconds, callback) {
+    return execScript('seekForward', seconds, callback);
+};
+
+exports.seekBackward = function (seconds, callback) {
+    return execScript('seekBackward', seconds, callback);
 };
 
 exports.jumpTo = function (position, callback) {

--- a/test/test.js
+++ b/test/test.js
@@ -2,6 +2,7 @@ var spotify = require('../lib/spotify-node-applescript.js');
 var expect = require('chai').expect;
 
 var COLDPLAY_TROUBLE_ID = 'spotify:track:0R8P9KfGJCDULmlEoBagcO'
+var COLDPLAY_TROUBLE_PLAYTIME_SEC = 273
 
 describe('Spotify Controller', function () {
 
@@ -200,6 +201,60 @@ describe('Spotify Controller', function () {
                             expect(state.volume).to.be.within(45, 55);
                             done();
                         });
+                    });
+                });
+            });
+        });
+    });
+
+    // Seek forward and backward
+
+    it('should seek forward', function (done) {
+        // first do jumpTo 0 in case position is at the max
+        spotify.jumpTo(0, function () {
+            spotify.seekForward(5, function () {
+                spotify.getState(function (error, state) {
+                    expect(state.position).to.be.gte(5);
+                    done();
+                });
+            });
+        });
+    });
+
+    it('should seek backward', function (done) {
+        // first do jumpTo 15 in case position is at 0
+        spotify.jumpTo(15, function () {
+            spotify.seekBackward(5, function () {
+                spotify.getState(function (error, state) {
+                    expect(state.position).to.be.gte(10);
+                    done();
+                });
+            });
+        });
+    });
+
+    it('should set position to 0 on seeking foward exceeding max', function (done) {
+        // first do jumpTo to emulate overflow when seeking forward
+        spotify.jumpTo(COLDPLAY_TROUBLE_PLAYTIME_SEC - 3, function () {
+            spotify.getState(function (error, state) {
+                spotify.seekForward(5, function () {
+                    spotify.getState(function (error, state) {
+                        expect(state.position).to.equal(0);
+                        done();
+                    });
+                });
+            });
+        });
+    });
+
+    it('should set position to 0 on seeking foward exceeding min', function (done) {
+        // first do jumpTo to emulate overflow when seeking backward
+        spotify.jumpTo(2, function () {
+            spotify.getState(function (error, state) {
+                spotify.seekBackward(5, function () {
+                    spotify.getState(function (error, state) {
+                        expect(state.position).to.equal(0);
+                        done();
                     });
                 });
             });

--- a/test/test.js
+++ b/test/test.js
@@ -275,7 +275,10 @@ describe('Spotify Controller', function () {
             expect(track.popularity).to.be.a('number');
             expect(track.id).to.equal(COLDPLAY_TROUBLE_ID);
             expect(track.album_artist).to.equal('Coldplay');
-            expect(track.artwork_url).to.contain('image/495b0549379fc4c324445fd7d2bfa219a8c18a90');
+            expect(track.artwork_url).to.satisfy(function (url) {
+                return url.endsWith('image/ab67616d0000b2733d92b2ad5af9fbc8637425f0')
+                    || url.endsWith('image/495b0549379fc4c324445fd7d2bfa219a8c18a90')
+            })
             expect(track.spotify_url).to.equal('spotify:track:0R8P9KfGJCDULmlEoBagcO');
 
             done();

--- a/test/test.js
+++ b/test/test.js
@@ -1,20 +1,22 @@
 var spotify = require('../lib/spotify-node-applescript.js');
 var expect = require('chai').expect;
 
-describe('Spotify Controller', function(){
+var COLDPLAY_TROUBLE_ID = 'spotify:track:0R8P9KfGJCDULmlEoBagcO'
+
+describe('Spotify Controller', function () {
 
     // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
     // Make sure spotify is open before running these tests
     // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-    beforeEach(function(done){
-        spotify.playTrackInContext('spotify:track:0R8P9KfGJCDULmlEoBagcO', 'spotify:album:6ZG5lRT77aJ3btmArcykra', function(){
+    beforeEach(function (done) {
+        spotify.playTrackInContext('spotify:track:0R8P9KfGJCDULmlEoBagcO', 'spotify:album:6ZG5lRT77aJ3btmArcykra', function () {
             done();
         });
     });
 
-    after(function(done){
-        spotify.pause(function(){
+    after(function (done) {
+        spotify.pause(function () {
             done();
         });
         spotify.setRepeating(false);
@@ -23,9 +25,9 @@ describe('Spotify Controller', function(){
 
     // Open and get track
 
-    it('play track', function(done){
-        spotify.playTrack('spotify:track:6JEK0CvvjDjjMUBFoXShNZ', function(){
-            spotify.getTrack(function(error, track){
+    it('play track', function (done) {
+        spotify.playTrack('spotify:track:6JEK0CvvjDjjMUBFoXShNZ', function () {
+            spotify.getTrack(function (error, track) {
                 expect(track.name).to.equal('Never Gonna Give You Up');
                 done();
             });
@@ -34,19 +36,19 @@ describe('Spotify Controller', function(){
 
     // Playback control
 
-    it('should pause a track', function(done){
-        spotify.pause(function(){
-            spotify.getState(function(error, state){
+    it('should pause a track', function (done) {
+        spotify.pause(function () {
+            spotify.getState(function (error, state) {
                 expect(state.state).to.equal('paused');
                 done();
             });
         });
     });
 
-    it('should resume playing a track after pausing', function(done){
-        spotify.pause(function(){
-            spotify.play(function(){
-                spotify.getState(function(error, state){
+    it('should resume playing a track after pausing', function (done) {
+        spotify.pause(function () {
+            spotify.play(function () {
+                spotify.getState(function (error, state) {
                     expect(state.state).to.equal('playing');
                     done();
                 });
@@ -54,12 +56,12 @@ describe('Spotify Controller', function(){
         });
     });
 
-    it('should play and pause a track', function(done){
-        spotify.playPause(function(){
-            spotify.getState(function(error, state){
+    it('should play and pause a track', function (done) {
+        spotify.playPause(function () {
+            spotify.getState(function (error, state) {
                 expect(state.state).to.equal('paused');
-                spotify.playPause(function(){
-                    spotify.getState(function(error, state){
+                spotify.playPause(function () {
+                    spotify.getState(function (error, state) {
                         expect(state.state).to.equal('playing');
                         done();
                     });
@@ -68,20 +70,20 @@ describe('Spotify Controller', function(){
         });
     });
 
-    it('should return playing track', function(done){
-        spotify.getTrack(function(error, track){
+    it('should return playing track', function (done) {
+        spotify.getTrack(function (error, track) {
             expect(track.artist).to.equal('Coldplay');
             expect(track.name).to.equal('Trouble');
             done();
         });
     });
 
-    it('should jump to a specific position of the song', function(done){
+    it('should jump to a specific position of the song', function (done) {
         // spotify needs some time to catch up with the jump or it will
         // simply return 0 as current player position
-        setTimeout(function(){
-            spotify.jumpTo(15, function(){
-                spotify.getState(function(err, state){
+        setTimeout(function () {
+            spotify.jumpTo(15, function () {
+                spotify.getState(function (err, state) {
                     expect(state.position).to.equal(15);
                     done();
                 });
@@ -89,33 +91,33 @@ describe('Spotify Controller', function(){
         }, 1100);
     });
 
- 	it('play next track', function(done){
-		spotify.next(function(error, track){
-			spotify.getTrack(function(error, track){
+    it('play next track', function (done) {
+        spotify.next(function (error, track) {
+            spotify.getTrack(function (error, track) {
                 expect(track.name).to.equal('Parachutes');
-				done();
-			});
-		});
-	});
+                done();
+            });
+        });
+    });
 
-	it('play previous track', function(done){
-		spotify.previous(function(error, track){
-			spotify.getTrack(function(error, track){
-				expect(track.name).to.equal('Yellow');
-				done();
-			});
-		});
-	});
+    it('play previous track', function (done) {
+        spotify.previous(function (error, track) {
+            spotify.getTrack(function (error, track) {
+                expect(track.name).to.equal('Yellow');
+                done();
+            });
+        });
+    });
 
     // Volumen control
 
-    it('should turn volume up', function(done){
+    it('should turn volume up', function (done) {
         // first do volumeDown in case volume is already 100
-        spotify.volumeDown(function(){
-            spotify.getState(function(error, state){
+        spotify.volumeDown(function () {
+            spotify.getState(function (error, state) {
                 var volume = state.volume;
-                spotify.volumeUp(function(){
-                    spotify.getState(function(error, state){
+                spotify.volumeUp(function () {
+                    spotify.getState(function (error, state) {
                         expect(state.volume).to.be.greaterThan(volume);
                         done();
                     });
@@ -124,13 +126,13 @@ describe('Spotify Controller', function(){
         });
     });
 
-    it('should turn volume down', function(done){
+    it('should turn volume down', function (done) {
         // first do volumeUp in case volume is already 0
-        spotify.volumeUp(function(){
-            spotify.getState(function(error, state){
+        spotify.volumeUp(function () {
+            spotify.getState(function (error, state) {
                 var volume = state.volume;
-                spotify.volumeDown(function(){
-                    spotify.getState(function(error, state){
+                spotify.volumeDown(function () {
+                    spotify.getState(function (error, state) {
                         expect(state.volume).to.be.lessThan(volume);
                         done();
                     });
@@ -139,13 +141,13 @@ describe('Spotify Controller', function(){
         });
     });
 
-    it('should not overflow on volume up', function(done){
+    it('should not overflow on volume up', function (done) {
         // first do setVolume to emulate overflow when volume up
-        spotify.setVolume(95, function(){
-            spotify.getState(function(error, state){
+        spotify.setVolume(95, function () {
+            spotify.getState(function (error, state) {
                 var volume = state.volume;
-                spotify.volumeUp(function(){
-                    spotify.getState(function(error, state){
+                spotify.volumeUp(function () {
+                    spotify.getState(function (error, state) {
                         expect(state.volume).to.be.greaterThan(volume);
                         done();
                     });
@@ -154,13 +156,13 @@ describe('Spotify Controller', function(){
         });
     });
 
-    it('should not overflow on volume down', function(done){
+    it('should not overflow on volume down', function (done) {
         // first do setVolume to emulate overflow when volume down
-        spotify.setVolume(5, function(){
-            spotify.getState(function(error, state){
+        spotify.setVolume(5, function () {
+            spotify.getState(function (error, state) {
                 var volume = state.volume;
-                spotify.volumeDown(function(){
-                    spotify.getState(function(error, state){
+                spotify.volumeDown(function () {
+                    spotify.getState(function (error, state) {
                         expect(state.volume).to.be.lessThan(volume);
                         done();
                     });
@@ -169,9 +171,9 @@ describe('Spotify Controller', function(){
         });
     });
 
-    it('should set the volume', function(done){
-        spotify.setVolume(0, function(){
-            spotify.getState(function(err, state){
+    it('should set the volume', function (done) {
+        spotify.setVolume(0, function () {
+            spotify.getState(function (err, state) {
                 if (err) throw err;
 
                 expect(state.volume).to.equal(0);
@@ -180,17 +182,17 @@ describe('Spotify Controller', function(){
         });
     });
 
-    it('should mute and unmute the volume', function(done){
-        spotify.setVolume(50, function(){
-            spotify.muteVolume(function(err, state){
-                spotify.getState(function(err, state){
+    it('should mute and unmute the volume', function (done) {
+        spotify.setVolume(50, function () {
+            spotify.muteVolume(function (err, state) {
+                spotify.getState(function (err, state) {
                     if (err) throw err;
 
                     // volume now should be 0
                     expect(state.volume).to.equal(0);
 
-                    spotify.unmuteVolume(function(err, state){
-                        spotify.getState(function(err, state){
+                    spotify.unmuteVolume(function (err, state) {
+                        spotify.getState(function (err, state) {
                             if (err) throw err;
 
                             // volume now should be 50 again
@@ -206,8 +208,8 @@ describe('Spotify Controller', function(){
 
     // State retrieval
 
-    it('should return current track', function(done){
-        spotify.getTrack(function(error, track){
+    it('should return current track', function (done) {
+        spotify.getTrack(function (error, track) {
             expect(track.name).to.equal('Trouble');
             expect(track.artist).to.equal('Coldplay');
             expect(track.album).to.equal('Parachutes');
@@ -216,7 +218,7 @@ describe('Spotify Controller', function(){
             expect(track.played_count).to.be.a('number');
             expect(track.track_number).to.equal(6);
             expect(track.popularity).to.be.a('number');
-            expect(track.id).to.equal('spotify:track:0R8P9KfGJCDULmlEoBagcO');
+            expect(track.id).to.equal(COLDPLAY_TROUBLE_ID);
             expect(track.album_artist).to.equal('Coldplay');
             expect(track.artwork_url).to.contain('image/495b0549379fc4c324445fd7d2bfa219a8c18a90');
             expect(track.spotify_url).to.equal('spotify:track:0R8P9KfGJCDULmlEoBagcO');
@@ -225,8 +227,8 @@ describe('Spotify Controller', function(){
         });
     });
 
-    it('should return player status', function(done){
-        spotify.getState(function(error, state){
+    it('should return player status', function (done) {
+        spotify.getState(function (error, state) {
             expect(state.state).to.equal('playing');
             expect(state.volume).to.be.a('number');
             expect(state.position).to.be.a('number');
@@ -236,17 +238,17 @@ describe('Spotify Controller', function(){
         });
     });
 
-    it('should return true when spotify is running', function(done) {
-        spotify.isRunning(function(error, isRunning) {
+    it('should return true when spotify is running', function (done) {
+        spotify.isRunning(function (error, isRunning) {
             expect(error).to.be.null;
             expect(isRunning).to.be.true;
             done();
         });
     });
 
-    it('should set the repeating to false', function(done){
-        spotify.setRepeating(false, function(){
-            spotify.isRepeating(function(err, repeating){
+    it('should set the repeating to false', function (done) {
+        spotify.setRepeating(false, function () {
+            spotify.isRepeating(function (err, repeating) {
                 if (err) throw err;
 
                 expect(repeating).to.equal(false);
@@ -255,9 +257,9 @@ describe('Spotify Controller', function(){
         });
     });
 
-    it('should set the repeating to true', function(done){
-        spotify.setRepeating(true, function(){
-            spotify.isRepeating(function(err, repeating){
+    it('should set the repeating to true', function (done) {
+        spotify.setRepeating(true, function () {
+            spotify.isRepeating(function (err, repeating) {
                 if (err) throw err;
 
                 expect(repeating).to.equal(true);
@@ -266,9 +268,9 @@ describe('Spotify Controller', function(){
         });
     });
 
-    it('should set the shuffling to false', function(done){
-        spotify.setShuffling(false, function(){
-            spotify.isShuffling(function(err, shuffling){
+    it('should set the shuffling to false', function (done) {
+        spotify.setShuffling(false, function () {
+            spotify.isShuffling(function (err, shuffling) {
                 if (err) throw err;
 
                 expect(shuffling).to.equal(false);
@@ -277,9 +279,9 @@ describe('Spotify Controller', function(){
         });
     });
 
-    it('should set the shuffling to true', function(done){
-        spotify.setShuffling(true, function(){
-            spotify.isShuffling(function(err, shuffling){
+    it('should set the shuffling to true', function (done) {
+        spotify.setShuffling(true, function () {
+            spotify.isShuffling(function (err, shuffling) {
                 if (err) throw err;
 
                 expect(shuffling).to.equal(true);
@@ -288,10 +290,10 @@ describe('Spotify Controller', function(){
         });
     });
 
-    it('should toggle the repeating', function(done){
-        spotify.setRepeating(false, function(){
-            spotify.toggleRepeating(function(err){
-                spotify.isRepeating(function(err, repeating){
+    it('should toggle the repeating', function (done) {
+        spotify.setRepeating(false, function () {
+            spotify.toggleRepeating(function (err) {
+                spotify.isRepeating(function (err, repeating) {
                     if (err) throw err;
 
                     expect(repeating).to.equal(true);
@@ -301,10 +303,10 @@ describe('Spotify Controller', function(){
         });
     });
 
-    it('should toggle the shuffling', function(done){
-        spotify.setShuffling(false, function(){
-            spotify.toggleShuffling(function(err){
-                spotify.isShuffling(function(err, shuffling){
+    it('should toggle the shuffling', function (done) {
+        spotify.setShuffling(false, function () {
+            spotify.toggleShuffling(function (err) {
+                spotify.isShuffling(function (err, shuffling) {
                     if (err) throw err;
 
                     expect(shuffling).to.equal(true);


### PR DESCRIPTION
Hi, thank you for running this awesome project. I'm opening this PR to add seeking capability for extending [vscode-spotify](https://github.com/ShyykoSerhiy/vscode-spotify).

You can find the main changes in 14d3e45. The others are just formatting and fixing the original tests. I hope you like this PR and let it merged soon.

Regarding the quality of this PR, you can check the tests written in the commit above. Also, I've run the test suite +10 times on my local as followed by:
```
❯ yarn test                       
yarn run v1.22.10
$ mocha


  Spotify Controller
    ✓ play track (894ms)
    ✓ should pause a track (357ms)
    ✓ should resume playing a track after pausing (497ms)
    ✓ should play and pause a track (611ms)
    ✓ should return playing track (196ms)
    ✓ should jump to a specific position of the song (1401ms)
    ✓ play next track (325ms)
    ✓ play previous track (477ms)
    ✓ should turn volume up (611ms)
    ✓ should turn volume down (610ms)
    ✓ should not overflow on volume up (600ms)
    ✓ should not overflow on volume down (671ms)
    ✓ should set the volume (305ms)
    ✓ should mute and unmute the volume (950ms)
    ✓ should seek forward (694ms)
    ✓ should seek backward (541ms)
    ✓ should set position to 0 on seeking foward exceeding max (607ms)
    ✓ should set position to 0 on seeking foward exceeding min (661ms)
    ✓ should return current track (192ms)
    ✓ should return player status (166ms)
    ✓ should return true when spotify is running (82ms)
    ✓ should set the repeating to false (346ms)
    ✓ should set the repeating to true (298ms)
    ✓ should set the shuffling to false (299ms)
    ✓ should set the shuffling to true (353ms)
    ✓ should toggle the repeating (487ms)
    ✓ should toggle the shuffling (450ms)


  27 passing (18s)

✨  Done in 18.34s.
```